### PR TITLE
Fixed valid matches not saving

### DIFF
--- a/src/services/match-service/service.js
+++ b/src/services/match-service/service.js
@@ -18,8 +18,6 @@ MatchService.prototype.get = function (params) {
 
 // TODO: consider reworking this horrible CRUD system
 MatchService.prototype.create = function (match) {
-
-  // when creating a new tournament, tournament = tournament.id
   return this.matches.add(Object.assign(match, { matchId: `${match.tournament}-${match.number}` }));
 };
 

--- a/src/ui/match/add.js
+++ b/src/ui/match/add.js
@@ -108,21 +108,16 @@ export default class MatchAdd extends Component {
   }
 
   saveMatch () {
-    const teamPromises = this.state.opponents.concat(this.state.allies)
-      .map((team) => teamService.getByNumber(team.number));
+    const matchToSave = this.state;
+    
+    matchToSave.tournamentOptions = undefined;
 
-    Promise.all(teamPromises)
-      .then(([oppo1, oppo2, ally]) => {
-        const matchToSave = this.state;
+    matchToSave.team = this.props.navigation.state.params.team.number;
+    matchToSave.opponents = this.state.opponents.map(op => op.number);
+    matchToSave.allies = this.state.allies.map(ally => ally.number);
 
-        matchToSave.tournamentOptions = undefined;
-
-        matchToSave.team = this.props.navigation.state.params.team.id;
-        matchToSave.opponents = [oppo1.id, oppo2.id];
-        matchToSave.allies = [ally.id];
-
-        return matchService.create(matchToSave);
-      }).then(() => {
+    return matchService.create(matchToSave)
+      .then(() => {
         this.props.navigation.state.params.refresh();
         this.props.navigation.goBack();
       });

--- a/src/ui/match/list.js
+++ b/src/ui/match/list.js
@@ -77,7 +77,7 @@ export default class MatchList extends Component {
         this.setState({
           renderedMatchList: matches.reduce((accum, match) => {
             const renderedMatch = <Match
-                                    key={match.matchId}
+                                    key={match.id}
                                     match={match}
                                     detailClicked={() => this.props.navigation.navigate('MatchDetailScreen', match)}
                                     editClicked={() => this.props.navigation.navigate('MatchEditScreen', match)}/>;


### PR DESCRIPTION
fixed matches being rendered using their `matchId` instead of the unique id provided to every match object.

fixed matches saving with team ids for team/allies/opponents instead of team numbers.